### PR TITLE
Replaced wrong "UPLX" magic string in comment with "UPXL"

### DIFF
--- a/firmware/Core/Src/app.c
+++ b/firmware/Core/Src/app.c
@@ -313,7 +313,7 @@ void setup() {
 
 }
 
-// this is the main uart scan function. It ignores data until the magic UPLX string is seen
+// this is the main uart scan function. It ignores data until the magic UPXL string is seen
 static inline void handleIncomming() {
 	uartResetCrc();
 	//look for the 4 byte magic header sequence


### PR DESCRIPTION
That comment was misleading.